### PR TITLE
fixed bug in windows paths (ingore case fix)

### DIFF
--- a/src/coverage-parser.ts
+++ b/src/coverage-parser.ts
@@ -75,9 +75,13 @@ export class CoverageParser {
             let filePath = section.file;
             if(iopath.isAbsolute(section.file)){
                 //Convert to a path relative to the workspace root
-                filePath = filePath.replace(workspaceFolder.uri.fsPath, "");
+                if (filePath.toLowerCase().startsWith(workspaceFolder.uri.fsPath.toLowerCase()))
+                {
+                    filePath = filePath.substring(workspaceFolder.uri.fsPath.length);
+                }
+                section.file = filePath;
             }
-            
+
             sections.set(filePath, section);
         };
 


### PR DESCRIPTION
windows paths C:\path and c:\path are both works as absolute paths but replace() will not work, so file open in UI will fail in nonexistent file, wich is error on windows