### PR TITLE
fix recomputeStats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 			},
 			"devDependencies": {
 				"@types/glob": "^7.1.1",
+				"@types/lcov-parse": "^1.0.0",
 				"@types/node": "^13.11.0",
 				"@types/vscode": "^1.44.0",
 				"@typescript-eslint/eslint-plugin": "^2.26.0",
@@ -231,6 +232,12 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
+		},
+		"node_modules/@types/lcov-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/lcov-parse/-/lcov-parse-1.0.0.tgz",
+			"integrity": "sha512-OUhELB4cGtoAkBPr2/9zOe05f+Qijf7nUgx7MgPr/BNY272fiv7qWfrd02zPKb2n3xiWzYtZRXQnx0QWRxENVQ==",
 			"dev": true
 		},
 		"node_modules/@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.1",
+		"@types/lcov-parse": "^1.0.0",
 		"@types/node": "^13.11.0",
 		"@types/vscode": "^1.44.0",
 		"@typescript-eslint/eslint-plugin": "^2.26.0",
@@ -116,13 +117,12 @@
 		"webpack-cli": "^4.10.0"
 	},
 	"dependencies": {
-		"@vscode-logging/logger": "^1.2.3",
 		"@cvrg-report/clover-json": "^0.3.0",
 		"@cvrg-report/cobertura-json": "^0.1.3",
 		"@cvrg-report/jacoco-json": "^0.1.2",
+		"@vscode-logging/logger": "^1.2.3",
 		"lcov-parse": "1.0.0",
 		"rxjs": "^6.5.5"
 	},
-	"overrides": {
-	}
+	"overrides": {}
 }

--- a/src/coverage-parser.ts
+++ b/src/coverage-parser.ts
@@ -60,7 +60,7 @@ export class CoverageParser {
 
     private recomputeStats(data: any[] ) {
         data.forEach((section) => {
-            if(!section.hit || !section.found){
+            if(!section.lines.hit || !section.lines.found){
                 section.lines.hit = section.lines.details.reduce((a, b) => a + (b.hit > 0 ? 1 : 0), 0);
                 section.lines.found = section.lines.details.length;
             }


### PR DESCRIPTION
`section.hit` and `section.found` are always null.
it overwrides hit&found by 0 if details are empty.